### PR TITLE
Add no merge option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Options:
   -w, [--week=N]                                 # Relative week number. e.g. -w=1 for last week. 0 = current week.
                                                  # Default: 0
       [--show-author], [--no-show-author]        # Display author(s) with each commit message. e.g. Did stuff (Ghost Ninja)
+      [--no-merge]                               # Omit merge commit messages
       [--sort=SORT]                              # Show commits in ascending/descending order. Default: older commits on top, newer on bottom.
                                                  # Default: desc
                                                  # Possible values: asc, desc

--- a/lib/weekly_commits/cli.rb
+++ b/lib/weekly_commits/cli.rb
@@ -27,6 +27,11 @@ module WeeklyCommits
                   default: 'asc',
                   enum: %w[asc desc]
 
+    method_option :no_merge,
+                  type: :boolean,
+                  desc: 'Exclude merge commits',
+                  default: false
+
     def weekly_commits
       relative_week = options[:week]
       beg_week = relative_week.week.ago.beginning_of_week
@@ -38,6 +43,7 @@ module WeeklyCommits
         committer = options[:show_author] ? ' (%cn)'.magenta : ''
 
         commits = `git --no-pager log --after='#{git_date_format} 00:00' --before='#{git_date_format} 23:59' --pretty=format:'%s#{committer}'`
+        commits += ' --no-merges' if options[:no_merge]
 
         commits = commits.lines.reverse if options[:sort].casecmp('asc').zero?
 

--- a/spec/weekly_commits_spec.rb
+++ b/spec/weekly_commits_spec.rb
@@ -4,4 +4,16 @@ describe WeeklyCommits do
   it 'has a version number' do
     expect(WeeklyCommits::VERSION).not_to be nil
   end
+
+  context 'default options' do
+    let(:default_args) { [] }
+    let(:default_options) do
+      { week: 0, sort: 'asc' }
+    end
+
+    it 'lists commits for Monday through Friday' do
+      days_printed = 5
+      expect(WeeklyCommits::CLI.new(default_args, default_options).weekly_commits).to eq(days_printed)
+    end
+  end
 end


### PR DESCRIPTION
Merge commits are kinda noisy imo. A `no-merge` option would be nice.