### PR TITLE
Fix previous year bug and improve consistency

### DIFF
--- a/lib/weekly_commits/cli.rb
+++ b/lib/weekly_commits/cli.rb
@@ -39,7 +39,7 @@ module WeeklyCommits
       5.times do |day_count|
         date = beg_week + day_count.days
         week_title = date.strftime('%a, %e %b %Y')
-        git_date_format = date.strftime('%Y-%m-%e')
+        git_date_format = date.strftime('%Y-%m-%d')
         committer = options[:show_author] ? ' (%cn)'.magenta : ''
 
         git_log_command = "git --no-pager log --after='#{git_date_format} 00:00' --before='#{git_date_format} 23:59' --pretty=format:'%s#{committer}'"


### PR DESCRIPTION
`strftime` with `%e` produces: `git --no-pager log --after='2020-09- 3 00:00' `

Check out the "3" above. It needs to be "03".

`strftime` with `%d` produces: `git --no-pager log --after='2020-09-03 00:00' `

This change fixes https://github.com/dkarter/weekly_commits/issues/3